### PR TITLE
engage.xml - removed reference to the readme.txt as useless - it make…

### DIFF
--- a/engage/engage.xml
+++ b/engage/engage.xml
@@ -18,7 +18,6 @@
         <filename plugin="engage">jn-icons16.png</filename>
         <filename plugin="engage">jn-icons32.png</filename>
         <filename plugin="engage">stylesheet.css</filename>
-        <filename plugin="engage">readme.txt</filename>
     </files>
     <scriptfile>engage.scriptfile.php</scriptfile>
     <config>


### PR DESCRIPTION
…s installer looking for a nonexisting file.

Alternative would be copying readme.txt to the engage folder and living the reference in place.
